### PR TITLE
Perform a hard check on object locks in the dashboard reports.

### DIFF
--- a/includes/cwrc_dashboards.blocks.inc
+++ b/includes/cwrc_dashboards.blocks.inc
@@ -851,6 +851,9 @@ function cwrc_dashboards_project_locked_objects_block_form($form, &$form_state) 
 
   $wrapper = entity_metadata_wrapper('node', $node);
 
+  // Load islandora object lock utilities.
+  module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
+
   // Get solarium client.
   $client = cwrc_dashboards_get_solarium();
 
@@ -865,7 +868,8 @@ function cwrc_dashboards_project_locked_objects_block_form($form, &$form_state) 
       "RELS_EXT_locked-by_literal_s",
       "RELS_EXT_lock-expiry_literal_s",
     ))
-    ->addSort('workflow_date_current_dt', $query::SORT_DESC);
+    ->addSort('workflow_date_current_dt', $query::SORT_DESC)
+    ->setRows(100);
 
   // Get query results.
   $results = $client->select($query);
@@ -896,7 +900,11 @@ function cwrc_dashboards_project_locked_objects_block_form($form, &$form_state) 
 
   // Fill rows with objects.
   foreach ($results as $document) {
-    if (isset($document['RELS_EXT_locked-by_literal_s'])) {
+
+    // Load the full object to check lock status.
+    $object = islandora_object_load($document['PID']);
+    if (islandora_object_lock_is_locked($object)
+      && isset($document['RELS_EXT_locked-by_literal_s'])) {
       $locked_by = user_load_by_name($document['RELS_EXT_locked-by_literal_s']);
 
       if ($locked_by != NULL && isset($locked_by->uid)) {
@@ -948,6 +956,9 @@ function cwrc_dashboards_user_locked_objects_block_form($form, &$form_state) {
   // Get solarium client.
   $client = cwrc_dashboards_get_solarium();
 
+  // Load islandora object lock utilities.
+  module_load_include('inc', 'islandora_object_lock', 'includes/utilities');
+
   // Build select query for assigned to me block.
   $query = $client->createSelect();
   $helper = $query->getHelper();
@@ -958,13 +969,13 @@ function cwrc_dashboards_user_locked_objects_block_form($form, &$form_state) {
       "RELS_EXT_locked-by_literal_s",
       "RELS_EXT_lock-expiry_literal_s",
     ))
-    ->addSort('workflow_date_current_dt', $query::SORT_DESC);
+    ->addSort('workflow_date_current_dt', $query::SORT_DESC)
+    ->setRows(100);
 
   // Get query results.
   $results = $client->select($query);
 
-
-  // // Build table select form element.
+  // Build table select form element.
   $form['objects'] = array(
     '#type' => 'tableselect',
     '#options' => array(),
@@ -989,7 +1000,11 @@ function cwrc_dashboards_user_locked_objects_block_form($form, &$form_state) {
 
   // // Fill rows with objects.
   foreach ($results as $document) {
-    if (isset($document['RELS_EXT_locked-by_literal_s'])) {
+
+    // Load the full object to check lock status.
+    $object = islandora_object_load($document['PID']);
+    if (islandora_object_lock_is_locked($object)
+      && isset($document['RELS_EXT_locked-by_literal_s'])) {
 
       $time = strtotime($document['RELS_EXT_lock-expiry_literal_s']);
       if ($time != NULL && $time != FALSE) {


### PR DESCRIPTION
Limit the allowed items in the report to 100 and check the object locks against the live object in the repo.  This should limit the number of "false positives" appearing in the reports.